### PR TITLE
Test coverage reports with Coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,16 @@ jdk:
 
 install: true
 
+before_script:
+- openssl aes-256-cbc -K $encrypted_36f14abec38f_key -iv $encrypted_36f14abec38f_iv
+  -in settings.xml.enc -out settings.xml -d
+
 script:
 - rm -f build/maven/conf/settings.xml
 - cp settings.xml build/maven/conf/settings.xml
 - ./build/maven/bin/mvn clean deploy --settings=build/maven/conf/settings.xml
 
-before_script:
-- openssl aes-256-cbc -K $encrypted_36f14abec38f_key -iv $encrypted_36f14abec38f_iv
-  -in settings.xml.enc -out settings.xml -d
+after_success:
+  - if [[ "${TRAVIS_JOB_NUMBER}" = *".1"* ]]; then
+      mvn clean test jacoco:report coveralls:report;
+    fi

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![Build Status](https://travis-ci.org/ibm-bluemix-mobile-services/bms-pushnotifications-serversdk-java.svg?branch=master)](https://travis-ci.org/ibm-bluemix-mobile-services/bms-pushnotifications-serversdk-java)
 [![Build Status](https://travis-ci.org/ibm-bluemix-mobile-services/bms-pushnotifications-serversdk-java.svg?branch=development)](https://travis-ci.org/ibm-bluemix-mobile-services/bms-pushnotifications-serversdk-java)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/fe43788a157c4c4b971a8918d29c4469)](https://www.codacy.com/app/ibm-bluemix-mobile-services/bms-pushnotifications-serversdk-java?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=ibm-bluemix-mobile-services/bms-pushnotifications-serversdk-java&amp;utm_campaign=Badge_Grade)
+[![Coverage Status](https://coveralls.io/repos/github/ibm-bluemix-mobile-services/bms-pushnotifications-serversdk-java/badge.svg?branch=code-coverage)](https://coveralls.io/github/ibm-bluemix-mobile-services/bms-pushnotifications-serversdk-java?branch=code-coverage)
 
 The Push Notifications Server-side SDK for Java is used to send push notifications to registered devices through the [Push Notifications service in IBM® Bluemix](https://console.ng.bluemix.net/docs/services/mobilepush/index.html).
 

--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,14 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+			    <groupId>org.eluder.coveralls</groupId>
+			    <artifactId>coveralls-maven-plugin</artifactId>
+			    <version>4.3.0</version>
+				<configuration>
+					<sourceEncoding>UTF-8</sourceEncoding>
+				</configuration>
+			</plugin>
 			<!-- Uncomment this plugin to enable GPG signing of the artifacts, required in order to release to Maven Central. -->
 			<!-- <plugin>
 				<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This adds a badge to the README that displays the code coverage achieved by the unit tests.